### PR TITLE
Attach generated booking documents to admin requests

### DIFF
--- a/src/app/api/request-booking/route.ts
+++ b/src/app/api/request-booking/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import nodemailer from "nodemailer";
+import { createSimpleDocx } from "@/lib/docx";
 import { getServerT } from "@/lib/server-translations";
 
 type BookingRequestPayload = {
@@ -24,6 +25,128 @@ type BookingRequestPayload = {
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 const MIN_NIGHTS = 4;
+
+function formatCurrency(value: number) {
+  return `€${value.toFixed(2)}`;
+}
+
+function formatDate(value: string, locale: "en" | "es") {
+  return new Intl.DateTimeFormat(locale === "es" ? "es-ES" : "en-GB", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${value}T00:00:00Z`));
+}
+
+function paymentDueDate(start: string) {
+  const date = new Date(`${start}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() - 56);
+  return date.toISOString().slice(0, 10);
+}
+
+function createAgreementDocx(data: {
+  locale: "en" | "es";
+  firstName: string;
+  lastName: string;
+  guests: number;
+  start: string;
+  end: string;
+  nights: number;
+  total: number;
+}) {
+  const guestName = `${data.firstName} ${data.lastName}`;
+  const stay = data.locale === "es"
+    ? `${data.guests} huésped${data.guests === 1 ? "" : "es"} - ${formatDate(data.start, data.locale)} a ${formatDate(data.end, data.locale)}`
+    : `${data.guests} guest${data.guests === 1 ? "" : "s"} - ${formatDate(data.start, data.locale)} to ${formatDate(data.end, data.locale)}`;
+  const due = formatDate(paymentDueDate(data.start), data.locale);
+
+  if (data.locale === "es") {
+    return createSimpleDocx([
+      { text: "Casa Atlante", alignment: "center" },
+      { text: "Contrato de alquiler vacacional", alignment: "center", bold: true },
+      { text: "Información de la reserva", bold: true },
+      { text: "• Dirección de la propiedad: Carretera General Jedey, 42, 38759 El Paso, La Palma, España." },
+      { text: "• Teléfono en Casa Atlante: +34 675103382" },
+      { text: `• Nombre del huésped: ${guestName}` },
+      { text: `• Número de huéspedes y fechas reservadas: ${stay}` },
+      { text: `• Coste de alquiler: ${formatCurrency(data.total)}` },
+      { text: `Reserva: Para confirmar la reserva, el huésped debe pagar el coste total del alquiler antes del ${due}.`, bold: true },
+      { text: "Una vez confirmada la reserva mediante el pago, enviaremos las instrucciones completas de llegada a la casa y estaremos disponibles para cualquier pregunta. Los huéspedes harán el check-in de forma autónoma." },
+      { text: "Detalles de pago", bold: true },
+      { text: "Factura PayPal enviada por correo electrónico." },
+      { text: "Reembolsos y cancelaciones", bold: true },
+      { text: "• 100% de reembolso si los huéspedes cancelan al menos 30 días antes de la entrada." },
+      { text: "• 50% de reembolso si los huéspedes cancelan al menos 14 días antes de la entrada." },
+      { text: "• Sin reembolso si los huéspedes cancelan menos de 14 días antes de la entrada." },
+      { text: "Tarifas: Las tarifas se calculan según el número de huéspedes y la duración de la estancia. La ocupación no puede superar el número de huéspedes acordado." },
+      { text: "Limpieza y daños: La limpieza final, el cambio de ropa de cama, sábanas y toallas está incluido. Los huéspedes son responsables de los daños ocurridos durante su estancia." },
+      { text: "Disposiciones generales: El alojamiento dispone de jabón, papel higiénico, especias, sal y pimienta, aceite y vinagre, café y té. La casa se entrega con ropa de cama, toallas y equipamiento de cocina." },
+    ]);
+  }
+
+  return createSimpleDocx([
+    { text: "Casa Atlante", alignment: "center" },
+    { text: "Vacation Rental Agreement", alignment: "center", bold: true },
+    { text: "Booking information", bold: true },
+    { text: "• Property address: Carretera General Jedey, 42, 38759 El Paso, La Palma, Spain." },
+    { text: "• Phone number at Casa Atlante: +34 675103382" },
+    { text: `• Name of guest: ${guestName}` },
+    { text: `• Number of guests and dates booked: ${stay}` },
+    { text: `• Rental cost: ${formatCurrency(data.total)}` },
+    { text: `Reservation: In order to confirm the reservation the guest needs to pay the total rental cost by the ${due}.`, bold: true },
+    { text: "Once the booking is confirmed through payment, we will send complete directions to the house and we will be available for any questions the guests might have. The guests will do self check-in." },
+    { text: "Payment details", bold: true },
+    { text: "PayPal invoice sent through email." },
+    { text: "Refund and Cancellations:", bold: true },
+    { text: "• 100% refund if guests cancel at least 30 days before check-in." },
+    { text: "• 50% refund if guests cancel at least 14 days before check-in." },
+    { text: "• No refund if guests cancel less than 14 days before check-in." },
+    { text: "Rates: The rates are calculated based on the number of guests and the length of stay. The occupancy may not exceed the guest count agreed upon." },
+    { text: "Cleaning & Damages: The final cleaning, change of bedding, linens and towels is free of charge and will be done during the mid stay for stays longer than 3 weeks. Guests are responsible for damage that occurs during their stay." },
+    { text: "General provisions: The accommodation is equipped with soap, toilet paper, spices, salt and pepper, oil and vinegar, coffee, tea, linens, towels and kitchen equipment." },
+  ]);
+}
+
+function createInvoiceDocx(data: {
+  locale: "en" | "es";
+  firstName: string;
+  lastName: string;
+  email: string;
+  guests: number;
+  start: string;
+  end: string;
+  nights: number;
+  subtotal: number;
+  tax: number;
+  total: number;
+}) {
+  const guestName = `${data.firstName} ${data.lastName}`;
+  const issued = formatDate(new Date().toISOString().slice(0, 10), data.locale);
+  const due = formatDate(paymentDueDate(data.start), data.locale);
+  const stayLine = data.locale === "es"
+    ? `Estancia ${data.guests} persona${data.guests === 1 ? "" : "s"}, ${data.nights} noche${data.nights === 1 ? "" : "s"}, ${formatDate(data.start, data.locale)} a ${formatDate(data.end, data.locale)}`
+    : `Stay for ${data.guests} people, ${data.nights} night${data.nights === 1 ? "" : "s"}, ${formatDate(data.start, data.locale)} to ${formatDate(data.end, data.locale)}`;
+
+  return createSimpleDocx([
+    { text: data.locale === "es" ? "Factura" : "Invoice", bold: true },
+    { text: "Samuel Rodriguez Medina", alignment: "right", bold: true },
+    { text: "NIF: 42417352Q", alignment: "right" },
+    { text: "Carretera General Jedey 42", alignment: "right" },
+    { text: "38759 El Paso", alignment: "right" },
+    { text: data.locale === "es" ? `Factura emitida: ${issued}` : `Invoice issued: ${issued}`, alignment: "right" },
+    { text: guestName },
+    { text: data.email },
+    { text: data.locale === "es" ? "Concepto" : "Description", spacingAfter: 80 },
+    { text: stayLine },
+    { text: data.locale === "es" ? `Importe sin IGIC: ${formatCurrency(data.subtotal)}` : `Amount excluding IGIC: ${formatCurrency(data.subtotal)}`, alignment: "right" },
+    { text: `IGIC (7%): ${formatCurrency(data.tax)}`, alignment: "right" },
+    { text: data.locale === "es" ? `Importe a pagar: ${formatCurrency(data.total)}` : `Amount due: ${formatCurrency(data.total)}`, alignment: "right", bold: true },
+    { text: data.locale === "es" ? `Confirmación con pago por transferencia bancaria antes del ${due}:` : `Confirmation with payment via bank transfer before ${due}:` },
+    { text: "IBAN: ES35 2100 7102 1107 0051 1115", bold: true },
+    { text: "SWIFT: CAIXESBBXXX", bold: true },
+  ]);
+}
 
 function normalizeDate(value?: string | null) {
   if (!value || !ISO_DATE.test(value)) return null;
@@ -138,6 +261,30 @@ export async function POST(req: NextRequest) {
   const total = subtotal + tax;
   const extraGuestsTotal = extraGuests * 20 * nights;
 
+  const agreementDocx = createAgreementDocx({
+    locale,
+    firstName,
+    lastName,
+    guests,
+    start,
+    end,
+    nights,
+    total,
+  });
+  const invoiceDocx = createInvoiceDocx({
+    locale,
+    firstName,
+    lastName,
+    email: fromEmail,
+    guests,
+    start,
+    end,
+    nights,
+    subtotal,
+    tax,
+    total,
+  });
+
   const text = [
     t("lineName", { firstName, lastName }),
     t("lineEmail", { fromEmail }),
@@ -168,6 +315,18 @@ export async function POST(req: NextRequest) {
         from: fromEmail,
         to: toEmail,
       },
+      attachments: [
+        {
+          filename: locale === "es" ? "contrato-alquiler-vacacional.docx" : "vacation-rental-agreement.docx",
+          content: agreementDocx,
+          contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        },
+        {
+          filename: locale === "es" ? "factura.docx" : "invoice.docx",
+          content: invoiceDocx,
+          contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        },
+      ],
     });
 
     // Send a copy to the sender for their records.

--- a/src/lib/docx.ts
+++ b/src/lib/docx.ts
@@ -1,0 +1,114 @@
+import { Buffer } from "node:buffer";
+
+type DocxParagraph = {
+  text: string;
+  bold?: boolean;
+  alignment?: "left" | "center" | "right";
+  spacingAfter?: number;
+};
+
+const encoder = new TextEncoder();
+
+function escapeXml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function crc32(buffer: Uint8Array) {
+  let crc = 0xffffffff;
+  for (let index = 0; index < buffer.length; index += 1) {
+    crc ^= buffer[index];
+    for (let i = 0; i < 8; i += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function dosDateTime(date = new Date()) {
+  const year = Math.max(1980, date.getFullYear());
+  const dosTime = (date.getHours() << 11) | (date.getMinutes() << 5) | Math.floor(date.getSeconds() / 2);
+  const dosDate = ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate();
+  return { dosDate, dosTime };
+}
+
+function createZip(files: Array<{ name: string; content: string }>) {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+  const { dosDate, dosTime } = dosDateTime();
+
+  for (const file of files) {
+    const name = Buffer.from(file.name);
+    const content = Buffer.from(encoder.encode(file.content));
+    const crc = crc32(content);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(0, 6);
+    local.writeUInt16LE(0, 8);
+    local.writeUInt16LE(dosTime, 10);
+    local.writeUInt16LE(dosDate, 12);
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(content.length, 18);
+    local.writeUInt32LE(content.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    local.writeUInt16LE(0, 28);
+    localParts.push(local, name, content);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(20, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(0, 8);
+    central.writeUInt16LE(0, 10);
+    central.writeUInt16LE(dosTime, 12);
+    central.writeUInt16LE(dosDate, 14);
+    central.writeUInt32LE(crc, 16);
+    central.writeUInt32LE(content.length, 20);
+    central.writeUInt32LE(content.length, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt16LE(0, 30);
+    central.writeUInt16LE(0, 32);
+    central.writeUInt16LE(0, 34);
+    central.writeUInt16LE(0, 36);
+    central.writeUInt32LE(0, 38);
+    central.writeUInt32LE(offset, 42);
+    centralParts.push(central, name);
+    offset += local.length + name.length + content.length;
+  }
+
+  const centralSize = centralParts.reduce((sum, part) => sum + part.length, 0);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(0, 4);
+  end.writeUInt16LE(0, 6);
+  end.writeUInt16LE(files.length, 8);
+  end.writeUInt16LE(files.length, 10);
+  end.writeUInt32LE(centralSize, 12);
+  end.writeUInt32LE(offset, 16);
+  end.writeUInt16LE(0, 20);
+
+  return Buffer.concat([...localParts, ...centralParts, end]);
+}
+
+function paragraph({ text, bold, alignment = "left", spacingAfter = 160 }: DocxParagraph) {
+  const align = alignment === "left" ? "" : `<w:jc w:val=\"${alignment}\"/>`;
+  const spacing = `<w:spacing w:after=\"${spacingAfter}\"/>`;
+  const runProps = bold ? "<w:rPr><w:b/></w:rPr>" : "";
+  return `<w:p><w:pPr>${align}${spacing}</w:pPr><w:r>${runProps}<w:t xml:space=\"preserve\">${escapeXml(text)}</w:t></w:r></w:p>`;
+}
+
+export function createSimpleDocx(paragraphs: DocxParagraph[]) {
+  const documentXml = `<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><w:document xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><w:body>${paragraphs.map(paragraph).join("")}<w:sectPr><w:pgSz w:w=\"11906\" w:h=\"16838\"/><w:pgMar w:top=\"1440\" w:right=\"1440\" w:bottom=\"1440\" w:left=\"1440\"/></w:sectPr></w:body></w:document>`;
+
+  return createZip([
+    { name: "[Content_Types].xml", content: `<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\"><Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/><Default Extension=\"xml\" ContentType=\"application/xml\"/><Override PartName=\"/word/document.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml\"/></Types>` },
+    { name: "_rels/.rels", content: `<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"word/document.xml\"/></Relationships>` },
+    { name: "word/document.xml", content: documentXml },
+  ]);
+}


### PR DESCRIPTION
### Motivation
- Automatically produce the two reference forms (rental agreement and invoice) pre-filled from booking data so the admin receives them as `.docx` attachments instead of creating them manually.
- Ensure the generated documents are localized to the website language at send time (`en` / `es`).

### Description
- Add a lightweight DOCX writer at `src/lib/docx.ts` that builds a minimal Word package (XML + ZIP + CRC) without external dependencies and supports simple paragraphs with alignment and bolding.
- Generate a localized vacation rental agreement and an invoice in `src/app/api/request-booking/route.ts` using booking fields (name, email, dates, guest count, price breakdown, IGIC, payment due) and language-aware formatting.
- Attach both generated `.docx` files with localized filenames to the admin email sent by the booking API and send the regular copy email to the guest.
- Keep existing email text unchanged and reuse the current localization (`getServerT`) to select language and strings.

### Testing
- Ran `npm run lint` which completed successfully.
- Ran TypeScript checks with `npx tsc --noEmit --ignoreDeprecations 6.0` which completed successfully.
- Ran `npm run build` which failed in this environment due to Next.js being unable to fetch Google Fonts from `fonts.googleapis.com`, unrelated to the new code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4105c562bc8332a18d70673dec08ba)